### PR TITLE
Allow getting a single value using opts.dest

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ const server = Server(config)
 
 ## API
 
-### `sbot.about.get(cb)`
+### `sbot.about.get(opts, cb)`
 
 Get the current state of the about view. This will wait until the view is up to date, if necessary.
+
+`opts` is optional, if `opts.dest` is provided only the specific key will be returned from the underlying cache.
 
 `cb(err, data)` is a standard callback function where `data` is of the form:
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,20 @@ exports.manifest = {
 }
 
 exports.init = function (ssb, config) {
-  return ssb._flumeUse('about', FlumeReduce(1, reduce, map))
+  var index = ssb._flumeUse('about', FlumeReduce(1, reduce, map))
+
+  return {
+    get: function(opts, cb) {
+      if (opts && opts.dest) {
+        index.get(function(err, value) {
+          if (err) return cb(err)
+          cb(null, value[opts.dest])
+        })
+      } else
+        index.get(opts, cb)
+    },
+    stream: index.stream
+  }
 }
 
 function reduce (result, item) {


### PR DESCRIPTION
This is to make it faster to just get a single value from the cache instead of everything. I need this for lazy about in patchcore.